### PR TITLE
修复 UIE 开发 runClient 与 Mixin refmap 行为

### DIFF
--- a/addons/ui-enhancements-server/build.gradle
+++ b/addons/ui-enhancements-server/build.gradle
@@ -84,6 +84,10 @@ test {
     javaLauncher.set(javaToolchains.launcherFor { languageVersion = JavaLanguageVersion.of(25) })
 }
 
+tasks.named('genSources') {
+    enabled = false
+}
+
 // Unimined wires Minecraft and Forge to main after source-set creation.
 sourceSets.test.compileClasspath += sourceSets.main.compileClasspath
 sourceSets.test.runtimeClasspath += sourceSets.main.runtimeClasspath

--- a/addons/ui-enhancements-server/build.gradle
+++ b/addons/ui-enhancements-server/build.gradle
@@ -39,7 +39,10 @@ dependencies {
 unimined.minecraft {
     version '1.12.2'
     mappings { mcp('stable', '39-1.12') }
-    cleanroom { loader '0.6.1-alpha' }
+    cleanroom {
+        loader '0.6.1-alpha'
+        runs.off = true
+    }
     defaultRemapJar = false
     remap(tasks.named('jar').get())
 }
@@ -91,3 +94,11 @@ tasks.named('genSources') {
 // Unimined wires Minecraft and Forge to main after source-set creation.
 sourceSets.test.compileClasspath += sourceSets.main.compileClasspath
 sourceSets.test.runtimeClasspath += sourceSets.main.runtimeClasspath
+
+tasks.register('stageUiEnhancementsServerRelease', Sync) {
+    group = 'distribution'
+    description = 'Stages only the remapped, installable UI Enhancements Server JAR.'
+    dependsOn tasks.named('build'), tasks.named('remapJar')
+    from(layout.buildDirectory.file("libs/neofontrender-ui-enhancements-server-${project.version}.jar"))
+    into rootProject.layout.buildDirectory.dir('release/uie-server')
+}

--- a/addons/ui-enhancements/build.gradle
+++ b/addons/ui-enhancements/build.gradle
@@ -184,6 +184,10 @@ tasks.register('stageUiEnhancementsRelease', Sync) {
     into rootProject.layout.buildDirectory.dir('release/uie')
 }
 
+tasks.named('genSources') {
+    enabled = false
+}
+
 jar {
     from('NOTICE.md') {
         into 'META-INF'

--- a/addons/ui-enhancements/build.gradle
+++ b/addons/ui-enhancements/build.gradle
@@ -65,6 +65,7 @@ dependencies {
     // Chinese segmentation and dictionary used by TabbyChat spell checking.
     // Cleanroom already supplies a compatible commons-lang3, so avoid embedding 3.3.1.
     contain('com.huaban:jieba-analysis:1.0.2') { transitive = false }
+    annotationProcessor 'com.cleanroommc:sponge-mixin:0.20.13+mixin.0.8.7'
     // Embedded SQL database backing the chat-history persistence layer.
     contain 'com.h2database:h2:2.3.232'
 
@@ -81,6 +82,22 @@ dependencies {
     testImplementation('dev.icyllis:arc3d-core:2026.2.0') { transitive = false }
     testImplementation 'org.lwjgl:lwjgl:3.4.1'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+def mixinRefMap = layout.buildDirectory.file('tmp/mixins/mixins.neofontrender_ui_enhancements-refmap.json')
+def mixinSrg = layout.buildDirectory.file('tmp/mixins/mixins.srg')
+def gradleUserHome = providers.environmentVariable('GRADLE_USER_HOME')
+        .getOrElse(System.getProperty('user.home') + '/.gradle')
+def mcpSrg = file("${gradleUserHome}/caches/minecraft/de/oceanlabs/mcp/mcp_stable/39/rfg_srgs/mcp-srg.srg")
+
+tasks.named('compileJava', JavaCompile).configure {
+    def mcpSrgFile = mcpSrg.absoluteFile
+    inputs.file(mcpSrgFile)
+    outputs.files(mixinSrg, mixinRefMap)
+    options.compilerArgs.addAll(
+            "-AreobfSrgFile=${mcpSrgFile.absolutePath}",
+            "-AoutSrgFile=${mixinSrg.get().asFile.absolutePath}",
+            "-AoutRefMapFile=${mixinRefMap.get().asFile.absolutePath}")
 }
 
 processResources {
@@ -136,6 +153,7 @@ jar {
     archiveClassifier = 'dev'
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     from(configurations.contain) { into '/' }
+    from(mixinRefMap)
     doFirst {
         def attributes = [
                 'ModType': 'CRL',

--- a/addons/ui-enhancements/src/main/java/neofontrender/addons/mixin/compat/MixinQuarkMapTooltip.java
+++ b/addons/ui-enhancements/src/main/java/neofontrender/addons/mixin/compat/MixinQuarkMapTooltip.java
@@ -3,11 +3,13 @@ package neofontrender.addons.mixin.compat;
 import net.minecraftforge.client.event.RenderTooltipEvent;
 import neofontrender.addons.tooltips.QuarkMapTooltipCompat;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+@Pseudo
 @Mixin(targets = "vazkii.quark.client.feature.MapTooltip", remap = false)
 public abstract class MixinQuarkMapTooltip {
     @Shadow(remap = false)

--- a/addons/ui-enhancements/src/main/java/neofontrender/addons/mixin/compat/MixinSalutationChatScreen.java
+++ b/addons/ui-enhancements/src/main/java/neofontrender/addons/mixin/compat/MixinSalutationChatScreen.java
@@ -5,6 +5,7 @@ import net.minecraft.client.gui.GuiTextField;
 import neofontrender.addons.chat.ChatKeyBindings;
 import neofontrender.addons.chat.ChatKeepOpenPolicy;
 import neofontrender.addons.mixin.AccessorGuiChatFeatures;
+import speiger.src.salutation.client.gui.chat.ChatScreen;
 import org.lwjgl.input.Keyboard;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Pseudo;
@@ -14,10 +15,10 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 /** Keeps Salutation's custom keyTyped path compatible with TabbyChat's removable PM prefix. */
 @Pseudo
-@Mixin(targets = "speiger.src.salutation.client.gui.chat.ChatScreen", remap = false)
+@Mixin(value = ChatScreen.class)
 public abstract class MixinSalutationChatScreen {
-    @Inject(method = {"keyTyped(CI)V", "func_73869_a(CI)V"}, at = @At("HEAD"), cancellable = true,
-            require = 1, remap = false)
+    @Inject(method = "keyTyped(CI)V", at = @At("HEAD"), cancellable = true,
+            require = 1)
     private void nfrUi$removePrivateCommandBlock(char typedChar, int keyCode, CallbackInfo ci) {
         GuiTextField inputField = nfrUi$inputField();
         if (keyCode == Keyboard.KEY_BACK && inputField != null
@@ -28,10 +29,10 @@ public abstract class MixinSalutationChatScreen {
         }
     }
 
-    @Inject(method = {"keyTyped(CI)V", "func_73869_a(CI)V"},
+    @Inject(method = "keyTyped(CI)V",
             at = @At(value = "INVOKE",
-                    target = "Lnet/minecraft/client/Minecraft;func_147108_a(Lnet/minecraft/client/gui/GuiScreen;)V",
-                    ordinal = 1), cancellable = true, require = 1, remap = false)
+                    target = "Lnet/minecraft/client/Minecraft;displayGuiScreen(Lnet/minecraft/client/gui/GuiScreen;)V",
+                    ordinal = 1), cancellable = true, require = 1)
     private void nfrUi$keepChatOpenAfterSend(char typedChar, int keyCode, CallbackInfo ci) {
         if (neofontrender.addons.chat.EnhancedChatConfigAccess.tabbedChatEnabled()
                 && TabbyChat.getInstance().getChat() != null

--- a/addons/ui-enhancements/src/main/java/neofontrender/addons/mixin/compat/MixinShoulderSurfingCrosshairMatrix.java
+++ b/addons/ui-enhancements/src/main/java/neofontrender/addons/mixin/compat/MixinShoulderSurfingCrosshairMatrix.java
@@ -13,7 +13,7 @@ import neofontrender.addons.flight.ShoulderSurfingMatrixFix;
 
 /** Leaves Shoulder Surfing's coordinate calculation intact without modifying the global HUD matrix. */
 @Pseudo
-@Mixin(targets = "com.teamderpy.shouldersurfing.client.ShoulderRenderer", remap = false)
+@Mixin(targets = "com.teamderpy.shouldersurfing.client.ShoulderRenderer")
 public abstract class MixinShoulderSurfingCrosshairMatrix {
     @Inject(method = "offsetCrosshair", at = @At("HEAD"))
     private void uie$markMatrixHookInstalled(ScaledResolution resolution, float partialTicks,
@@ -22,16 +22,13 @@ public abstract class MixinShoulderSurfingCrosshairMatrix {
     }
 
     @Redirect(method = "offsetCrosshair", at = @At(value = "INVOKE",
-            // Shoulder Surfing 2.9.6 is distributed in SRG form. This optional mixin has
-            // remap=false because its target is a third-party class, so name the invoked
-            // Minecraft method exactly as it appears in the installed 1.12.2 jar.
-            target = "Lnet/minecraft/client/renderer/GlStateManager;func_179094_E()V"))
+            target = "Lnet/minecraft/client/renderer/GlStateManager;pushMatrix()V"))
     private void uie$confineCrosshairPush() {
         if (!ShoulderSurfingFixConfig.enabled()) GlStateManager.pushMatrix();
     }
 
     @Redirect(method = "offsetCrosshair", at = @At(value = "INVOKE",
-            target = "Lnet/minecraft/client/renderer/GlStateManager;func_179109_b(FFF)V"))
+            target = "Lnet/minecraft/client/renderer/GlStateManager;translate(FFF)V"))
     private void uie$confineCrosshairTranslation(float x, float y, float z) {
         if (!ShoulderSurfingFixConfig.enabled()) GlStateManager.translate(x, y, z);
     }

--- a/build.gradle
+++ b/build.gradle
@@ -49,9 +49,9 @@ unimined.minecraft {
         runs.preLaunch('client', ':addons:ui-enhancements:prepareCombinedClientRun')
         runs.all {
             args += ['--username', minecraft_username]
-            // ModularUI's early Minecraft mixin is required for its key-binding accessors,
-            // while keeping development launches deterministic across loader updates.
-            // This applies only to Gradle development runs, never to the packaged mod.
+            // Dev runs use MCP-mapped classes, so reference-map remapping must stay disabled.
+            // Packaged jars still ship and use the refmap, so production SRG remapping is unaffected.
+            systemProperty('mixin.env.disableRefMap', 'true')
             systemProperty('fml.noSplash', 'true')
             if (extra_jvm_args?.trim()) jvmArgs += extra_jvm_args.split('\\s+').toList()
             if (enable_foundation_debug.toBoolean()) {


### PR DESCRIPTION
## 摘要

- 生成并打包 UIE Mixin refmap，保证生产环境 SRG 重映射可用。
- 仅在 Gradle 开发运行时关闭 refmap 应用，正式 JAR 仍保留 refmap。
- Salutation 和 Shoulder Surfing 可选 Mixin 改为 MCP 名称并通过 refmap 重映射，开发与生产环境都能正常注入。
- 禁用 UIE Server 的 run 任务，避免执行不带项目路径的 `gradlew runClient` 时，根项目结束后又启动 `:addons:ui-enhancements-server:runClient`。
- 新增 `stageUiEnhancementsServerRelease`，用于产出重映射后的 Server Companion JAR。

## 改动

- `addons/ui-enhancements/build.gradle`
  - 添加 Mixin 注解处理器。
  - 在 `compileJava` 阶段生成 UIE refmap。
  - 将 refmap 打入可安装 JAR。
- `build.gradle`
  - 仅对 Gradle 开发运行设置 `mixin.env.disableRefMap=true`，让开发环境保持 MCP 名称。
- `addons/ui-enhancements/src/main/java/neofontrender/addons/mixin/compat/MixinSalutationChatScreen.java`
  - 使用 MCP 方法名和目标名，通过 refmap 重映射，不再硬编码 SRG 名称。
- `addons/ui-enhancements/src/main/java/neofontrender/addons/mixin/compat/MixinShoulderSurfingCrosshairMatrix.java`
  - GlStateManager 注入目标改为 MCP 名称并通过 refmap 重映射。
- `addons/ui-enhancements-server/build.gradle`
  - 设置 `runs.off = true`，Server 项目不再生成 `runClient` / `runServer` 任务。
  - 新增 `stageUiEnhancementsServerRelease`。

## 验证

- `gradlew runClient --dry-run` 只调度 `:preRunClient` 和 `:runClient`。
- `gradlew :addons:ui-enhancements-server:build` 通过。
- `gradlew :addons:ui-enhancements:stageUiEnhancementsRelease` 通过。
- UIE release JAR 包含 `mixins.neofontrender_ui_enhancements-refmap.json`。
- refmap 中包含跨准星、Salutation 和 Shoulder Surfing 的预期映射。
- 开发 `runClient` 能通过 UIE 与 ModularUI 的 Mixin 注入阶段，并进入 Minecraft 启动流程。

