### PR TITLE
fix(ui-enhancements): render tracked flight quaternion

### DIFF
--- a/addons/ui-enhancements/src/main/java/neofontrender/addons/camera/CameraPresentationPolicy.java
+++ b/addons/ui-enhancements/src/main/java/neofontrender/addons/camera/CameraPresentationPolicy.java
@@ -20,7 +20,40 @@ final class CameraPresentationPolicy {
     /** Detached look rigs render from their frame instead of vanilla player yaw/pitch. */
     static boolean usesQuaternionView(boolean shoulderActive, boolean lookCameraActive,
                                       boolean droneActive) {
-        return !shoulderActive && (lookCameraActive || droneActive);
+        return usesQuaternionView(shoulderActive, lookCameraActive, droneActive, false);
+    }
+
+    /**
+     * A FlightCameraTracking attitude is already represented by the sampled CameraFrame.
+     * Present that same frame directly instead of mixing its roll with tick-owned Euler angles.
+     */
+    static boolean usesQuaternionView(boolean shoulderActive, boolean lookCameraActive,
+                                      boolean droneActive, boolean flightAuthoritativeFrame) {
+        return !shoulderActive && (lookCameraActive || droneActive || flightAuthoritativeFrame);
+    }
+
+    /**
+     * A player-anchored rig owns third-person orbit translation. This includes an authoritative
+     * Flight frame even when no built-in camera mode is active.
+     */
+    static boolean ownsPlayerAnchoredThirdPersonPresentation(boolean playerViewEntity,
+                                                              boolean shoulderActive,
+                                                              boolean lookCameraActive,
+                                                              boolean flightAuthoritativeFrame,
+                                                              int thirdPersonView) {
+        return playerViewEntity && thirdPersonView > 0
+                && (shoulderActive || lookCameraActive || flightAuthoritativeFrame);
+    }
+
+    static boolean suppressesVanillaThirdPersonDistance(boolean detachedPresentation,
+                                                        boolean playerAnchoredPresentation) {
+        return detachedPresentation || playerAnchoredPresentation;
+    }
+
+    /** A Flight frame already contains its local front-view turn; vanilla must not apply it again. */
+    static int vanillaOrientationPerspective(int thirdPersonView,
+                                             boolean flightQuaternionPresentation) {
+        return flightQuaternionPresentation && thirdPersonView == 2 ? 1 : thirdPersonView;
     }
 
     static int currentIndex(List<?> modes, Object activeMode) {

--- a/addons/ui-enhancements/src/main/java/neofontrender/addons/camera/CameraRenderBridge.java
+++ b/addons/ui-enhancements/src/main/java/neofontrender/addons/camera/CameraRenderBridge.java
@@ -21,8 +21,8 @@ public final class CameraRenderBridge {
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void cameraSetup(EntityViewRenderEvent.CameraSetup event) {
-        if (!CameraApi.isRenderOverrideActive()) return;
         CameraFrame frame = CameraApi.getFrame((float) event.getRenderPartialTicks());
+        if (!CameraApi.isRenderOverrideActive()) return;
         // Shoulder camera: apply offset in camera-local space (vanilla's rotations already
         // baked into GL matrix). anchoredViewTranslation() computes the local-space offset
         // via CameraPresentationTransform.translation(). Do NOT apply quaternion — vanilla's
@@ -35,8 +35,7 @@ public final class CameraRenderBridge {
             GlStateManager.translate((float) translation.x, (float) translation.y,
                     (float) translation.z);
         }
-        if (CameraPresentationPolicy.usesQuaternionView(CameraRuntime.isShoulderActive(),
-                CameraRuntime.isLookCameraActive(), CameraApi.isDroneActive())) {
+        if (CameraRuntime.usesQuaternionView(frame)) {
             applyQuaternionView(frame);
             event.setPitch(0.0F);
             event.setYaw(0.0F);

--- a/addons/ui-enhancements/src/main/java/neofontrender/addons/camera/CameraRuntime.java
+++ b/addons/ui-enhancements/src/main/java/neofontrender/addons/camera/CameraRuntime.java
@@ -47,6 +47,8 @@ public final class CameraRuntime {
     private static CameraFrame lastFrame = new CameraFrame(0L, 0.0F,
             CameraAttitude.IDENTITY, CameraAttitude.IDENTITY,
             new CameraVector(0.0D, 0.0D, 0.0D), new CameraVector(0.0D, 0.0D, 0.0D), true);
+    /** Private origin marker; CameraFrame's public pass-through flag is not a Flight identity. */
+    private static boolean lastFrameFlightAuthoritative;
     private static CameraSession activeSession;
     private static DroneInputGuard droneInput;
     private static FreeLookInputGuard freeLookInput;
@@ -107,14 +109,13 @@ public final class CameraRuntime {
     }
 
     /**
-     * Player-anchored rigs provide their own quaternion-relative orbit displacement, while a
-     * detached rig already stores the final origin in its adapter. Neither may also receive
-     * vanilla's four-block third-person displacement.
+     * Player-anchored rigs and full-quaternion Flight frames provide their own orbit
+     * displacement, while a detached rig already stores the final origin in its adapter. None
+     * may also receive vanilla's four-block third-person displacement.
      */
     public static synchronized boolean suppressesVanillaThirdPersonDisplacement() {
-        return usesDetachedThirdPersonPresentation()
-                || ((isShoulderActive() || isLookCameraActive())
-                && MC.gameSettings.thirdPersonView > 0);
+        return CameraPresentationPolicy.suppressesVanillaThirdPersonDistance(
+                usesDetachedThirdPersonPresentation(), isPlayerAnchoredCameraActive());
     }
 
     /** RenderPlayer normally suppresses the local user when a detached proxy is the view entity. */
@@ -123,18 +124,23 @@ public final class CameraRuntime {
     }
 
     /**
-     * Whether a player-anchored custom rig owns the presentation while the player remains the
-     * Minecraft render-view entity. Only RenderPlayer's local-user shortcut is bypassed here;
+     * Whether a player-anchored rig or Flight frame owns presentation while the player remains
+     * the Minecraft render-view entity. Only RenderPlayer's local-user shortcut is bypassed;
      * the render-view identity remains the player for movement, picking, and other consumers.
      */
     public static synchronized boolean isPlayerAnchoredCameraActive() {
-        return (isShoulderActive() || isLookCameraActive())
-                && MC.getRenderViewEntity() == MC.player;
+        return CameraPresentationPolicy.ownsPlayerAnchoredThirdPersonPresentation(
+                MC.getRenderViewEntity() == MC.player, isShoulderActive(), isLookCameraActive(),
+                isFlightQuaternionPresentationActive(), MC.gameSettings.thirdPersonView);
     }
 
     /** Camera-local GL translation for rigs whose render-view entity remains the player. */
     static synchronized CameraVector anchoredViewTranslation(CameraFrame frame) {
-        if (frame == null || (!isShoulderActive() && !isLookCameraActive())) return null;
+        if (frame == null || !CameraPresentationPolicy.ownsPlayerAnchoredThirdPersonPresentation(
+                MC.getRenderViewEntity() == MC.player, isShoulderActive(), isLookCameraActive(),
+                isFlightQuaternionPresentationFrame(frame), MC.gameSettings.thirdPersonView)) {
+            return null;
+        }
         return CameraPresentationTransform.translation(frame.viewAttitude(),
                 frame.bodyPosition(), frame.position());
     }
@@ -231,6 +237,7 @@ public final class CameraRuntime {
                 bodyPosition, position, targetPosition, velocity, kinematics.angular,
                 !isDroneActive() && !isLookCameraActive() && !isShoulderActive()
                         && !bodySample.flightAuthoritative);
+        lastFrameFlightAuthoritative = bodySample.flightAuthoritative;
         samplePartialTicks = value;
         sampleValid = true;
         return lastFrame;
@@ -636,9 +643,55 @@ public final class CameraRuntime {
         if (isDroneActive() || isLookCameraActive()) return true;
         if (isShoulderActive()) return CameraExternalCompat.internalCameraAllowed();
         EntityPlayerSP player = MC.player;
-        return player != null && !lastFrame.isVanillaPassThrough()
-                && FlightApi.queryCameraTracking(player, MC.getRenderPartialTicks()) != null
+        if (player == null) return false;
+        CameraFrame frame = sampleValid ? lastFrame : frame(MC.getRenderPartialTicks());
+        return isFlightAuthoritativeFrame(frame)
                 && CameraExternalCompat.internalCameraAllowed();
+    }
+
+    /**
+     * Decides presentation from the immutable render sample that is about to be drawn. The
+     * private Flight-origin marker was captured with the same sample, so no consumer may
+     * re-query that provider or confuse a generic provider's public pass-through flag with
+     * FlightCameraTracking.
+     */
+    public static synchronized boolean usesQuaternionView(CameraFrame frame) {
+        return frame != null && frame.sampleId() == lastFrame.sampleId()
+                && CameraPresentationPolicy.usesQuaternionView(isShoulderActive(),
+                isLookCameraActive(), isDroneActive(), isFlightAuthoritativeFrame(frame));
+    }
+
+    /**
+     * Returns the Flight attitude captured into this exact runtime sample, or {@code null} when
+     * the frame came from vanilla or another camera provider. Rendering code must use this rather
+     * than issue a second FlightApi query after CameraApi sampled the frame.
+     */
+    public static synchronized FlightAttitude flightAttitude(CameraFrame frame) {
+        if (!isFlightAuthoritativeFrame(frame)) return null;
+        CameraAttitude attitude = frame.bodyAttitude();
+        return new FlightAttitude(attitude.x, attitude.y, attitude.z, attitude.w);
+    }
+
+    /** Normalizes only vanilla orientCamera's duplicate front-view branch. */
+    public static synchronized int vanillaOrientationPerspective(int thirdPersonView) {
+        return CameraPresentationPolicy.vanillaOrientationPerspective(thirdPersonView,
+                isFlightQuaternionPresentationActive());
+    }
+
+    private static boolean isFlightAuthoritativeFrame(CameraFrame frame) {
+        return sampleValid && lastFrameFlightAuthoritative && frame != null
+                && frame.sampleId() == lastFrame.sampleId();
+    }
+
+    private static boolean isFlightQuaternionPresentationFrame(CameraFrame frame) {
+        return isFlightAuthoritativeFrame(frame) && !isShoulderActive()
+                && !isLookCameraActive() && !isDroneActive()
+                && CameraExternalCompat.internalCameraAllowed();
+    }
+
+    private static boolean isFlightQuaternionPresentationActive() {
+        CameraFrame frame = sampleValid ? lastFrame : frame(MC.getRenderPartialTicks());
+        return isFlightQuaternionPresentationFrame(frame);
     }
 
     public static synchronized void setDronePose(CameraVector position, CameraAttitude attitude) {

--- a/addons/ui-enhancements/src/main/java/neofontrender/addons/flight/FlightRollController.java
+++ b/addons/ui-enhancements/src/main/java/neofontrender/addons/flight/FlightRollController.java
@@ -15,6 +15,7 @@ import neofontrender.addons.api.input.CameraMouseInputEvent;
 import neofontrender.addons.api.input.InputAction;
 import neofontrender.addons.api.input.InputApi;
 import neofontrender.addons.api.camera.CameraApi;
+import neofontrender.addons.api.camera.CameraFrame;
 import neofontrender.addons.camera.CameraRuntime;
 import neofontrender.addons.compat.CameraExternalCompat;
 import neofontrender.addons.api.flight.FlightApi;
@@ -257,10 +258,8 @@ final class FlightRollController implements FlightRollNetwork.ClientListener, Fl
         }
         EntityPlayerSP player = mc.player;
         boolean active = active(player);
-        trackCamera(player);
-        boolean quaternionTracking = player != null
-                && FlightApi.queryCameraTracking(player, 1.0F) != null;
-        if (quaternionTracking) {
+        FlightCameraTracking quaternionTracking = trackCamera(player);
+        if (quaternionTracking != null) {
             barrelProgress = 1.0F;
             previousBarrel = barrel = 0.0F;
             barrelDirection = 0;
@@ -293,15 +292,15 @@ final class FlightRollController implements FlightRollNetwork.ClientListener, Fl
     @SubscribeEvent
     public void cameraSetup(EntityViewRenderEvent.CameraSetup event) {
         if (CameraExternalCompat.omnilookPresent()) return;
-        // CameraRuntime already sampled FlightCameraTracking for this render frame. Its LOWEST
-        // bridge applies that exact quaternion after event compatibility listeners have run.
-        // Shoulder and free-look cameras do NOT use a quaternion — they rely on vanilla's
-        // event-post rotations to apply the player's orientation. So we must still set the
-        // flight roll in the event for these modes.
-        // Drone mode uses a full quaternion, so we skip for drone only.
+        CameraFrame frame = CameraApi.getFrame((float) event.getRenderPartialTicks());
+        if (CameraApi.isRenderOverrideActive() && CameraRuntime.usesQuaternionView(frame)) {
+            return;
+        }
+        // CameraRuntime already sampled FlightCameraTracking for this render frame. A full
+        // quaternion view returns above; remaining Euler-compatible paths still need event roll.
         if (CameraApi.isRenderOverrideActive() && CameraApi.isDroneActive()) return;
         FlightRenderPose pose = resolveRenderPose(mc.player,
-                (float) event.getRenderPartialTicks());
+                (float) event.getRenderPartialTicks(), frame);
         if (pose != null) {
             FlightEulerAngles angles = pose.getCameraAngles();
             // FlightCameraTracking is active: trackCamera() already syncs player.rotationYaw/Pitch
@@ -315,12 +314,12 @@ final class FlightRollController implements FlightRollNetwork.ClientListener, Fl
         event.setRoll(event.getRoll() + renderedRoll((float) event.getRenderPartialTicks()));
     }
 
-    private void trackCamera(EntityPlayerSP player) {
-        if (player == null) return;
+    private FlightCameraTracking trackCamera(EntityPlayerSP player) {
+        if (player == null) return null;
         FlightCameraTracking tracking = FlightApi.queryCameraTracking(player, 1.0F);
         if (tracking == null) {
             trackedCameraRoll = renderedRoll(1.0F);
-            return;
+            return null;
         }
         FlightEulerAngles target = tracking.getAttitude().toMinecraftEuler(
                 player.rotationPitch, player.rotationYaw, trackedCameraRoll);
@@ -332,7 +331,7 @@ final class FlightRollController implements FlightRollNetwork.ClientListener, Fl
             player.rotationYaw += yawError;
             player.rotationPitch = targetPitch;
             trackedCameraRoll = target.rollDegrees;
-            return;
+            return tracking;
         }
         float response = tracking.getResponsePerSecond();
         float fraction = 1.0F - (float) Math.exp(-response / 20.0F);
@@ -340,6 +339,7 @@ final class FlightRollController implements FlightRollNetwork.ClientListener, Fl
         player.rotationYaw += trackingStep(yawError, fraction, maximumStep);
         player.rotationPitch += trackingStep(pitchError, fraction, maximumStep);
         trackedCameraRoll += trackingStep(rollError, fraction, maximumStep);
+        return tracking;
     }
 
     static float trackingStep(float error, float fraction, float maximumStep) {
@@ -347,17 +347,22 @@ final class FlightRollController implements FlightRollNetwork.ClientListener, Fl
         return Math.max(-maximumStep, Math.min(maximumStep, correction));
     }
 
-    private FlightRenderPose resolveRenderPose(EntityPlayerSP player, float partialTicks) {
-        if (player == null) { cachedRenderPose = null; return null; }
-        FlightCameraTracking tracking = FlightApi.queryCameraTracking(player, partialTicks);
-        if (tracking == null) {
+    /**
+     * Converts the exact CameraApi sample already selected for this frame. This render boundary
+     * deliberately never re-queries FlightCameraTracking: its attitude was captured by
+     * CameraRuntime before providers, modifiers, picking, and presentation consume the frame.
+     */
+    private FlightRenderPose resolveRenderPose(EntityPlayerSP player, float partialTicks,
+                                               CameraFrame frame) {
+        FlightAttitude attitude = player == null || player != mc.player
+                ? null : CameraRuntime.flightAttitude(frame);
+        if (attitude == null) {
             cachedRenderPose = null;
-            renderReferencePitch = player.rotationPitch;
-            renderReferenceYaw = player.rotationYaw;
+            renderReferencePitch = player == null ? 0.0F : player.rotationPitch;
+            renderReferenceYaw = player == null ? 0.0F : player.rotationYaw;
             renderReferenceRoll = renderedRoll(partialTicks);
             return null;
         }
-        FlightAttitude attitude = tracking.getAttitude();
         float amount = Math.max(0.0F, Math.min(1.0F, partialTicks));
         if (cachedRenderPose != null
                 && Math.abs(cachedRenderPose.getPartialTicks() - amount) < 1.0E-6F
@@ -583,7 +588,8 @@ final class FlightRollController implements FlightRollNetwork.ClientListener, Fl
     }
 
     @Override public FlightRenderPose renderPose(EntityPlayerSP player, float partialTicks) {
-        return resolveRenderPose(player, partialTicks);
+        CameraFrame frame = CameraApi.getFrame(partialTicks);
+        return resolveRenderPose(player, partialTicks, frame);
     }
 
     @Override public void setRoll(float degrees) { roll = degrees; }

--- a/addons/ui-enhancements/src/main/java/neofontrender/addons/mixin/MixinEntityRendererCameraPresentation.java
+++ b/addons/ui-enhancements/src/main/java/neofontrender/addons/mixin/MixinEntityRendererCameraPresentation.java
@@ -1,6 +1,7 @@
 package neofontrender.addons.mixin;
 
 import net.minecraft.client.renderer.EntityRenderer;
+import net.minecraft.client.settings.GameSettings;
 import neofontrender.addons.camera.CameraRuntime;
 import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
@@ -26,5 +27,16 @@ public abstract class MixinEntityRendererCameraPresentation {
     private float nfrUi$zeroDetachedCameraDistancePrevious(EntityRenderer renderer) {
         return CameraRuntime.suppressesVanillaThirdPersonDisplacement()
                 ? 0.0F : thirdPersonDistancePrev;
+    }
+
+    /**
+     * The exact Flight full-quaternion sample already applies its local front-view turn. Normalize
+     * all three orientCamera perspective reads consistently so vanilla never adds a second turn.
+     */
+    @Redirect(method = "orientCamera", at = @At(value = "FIELD", opcode = Opcodes.GETFIELD,
+            target = "Lnet/minecraft/client/settings/GameSettings;thirdPersonView:I"),
+            require = 3, expect = 3)
+    private int nfrUi$avoidDuplicateFlightFrontTurn(GameSettings settings) {
+        return CameraRuntime.vanillaOrientationPerspective(settings.thirdPersonView);
     }
 }

--- a/addons/ui-enhancements/src/test/java/neofontrender/addons/camera/CameraPresentationPolicyTest.java
+++ b/addons/ui-enhancements/src/test/java/neofontrender/addons/camera/CameraPresentationPolicyTest.java
@@ -38,6 +38,45 @@ class CameraPresentationPolicyTest {
     }
 
     @Test
+    void authoritativeFlightTrackingUsesTheSampledQuaternionWithoutASeparateRig() {
+        assertTrue(CameraPresentationPolicy.usesQuaternionView(false, false, false, true));
+        assertFalse(CameraPresentationPolicy.usesQuaternionView(true, false, false, true));
+        assertFalse(CameraPresentationPolicy.usesQuaternionView(false, false, false, false));
+    }
+
+    @Test
+    void playerAnchoredThirdPersonPresentationOwnsFlightAndRigDistance() {
+        assertFalse(CameraPresentationPolicy.ownsPlayerAnchoredThirdPersonPresentation(
+                true, false, false, false, 1));
+        assertFalse(CameraPresentationPolicy.ownsPlayerAnchoredThirdPersonPresentation(
+                true, false, false, false, 2));
+        assertTrue(CameraPresentationPolicy.ownsPlayerAnchoredThirdPersonPresentation(
+                true, false, false, true, 1));
+        assertTrue(CameraPresentationPolicy.ownsPlayerAnchoredThirdPersonPresentation(
+                true, false, false, true, 2));
+        assertTrue(CameraPresentationPolicy.ownsPlayerAnchoredThirdPersonPresentation(
+                true, true, false, false, 1));
+        assertFalse(CameraPresentationPolicy.ownsPlayerAnchoredThirdPersonPresentation(
+                true, true, false, true, 0));
+        assertFalse(CameraPresentationPolicy.ownsPlayerAnchoredThirdPersonPresentation(
+                false, false, false, true, 1));
+    }
+
+    @Test
+    void onlyFlightQuaternionFrontViewIsNormalizedForVanillaOrientation() {
+        assertEquals(1, CameraPresentationPolicy.vanillaOrientationPerspective(1, true));
+        assertEquals(1, CameraPresentationPolicy.vanillaOrientationPerspective(2, true));
+        assertEquals(2, CameraPresentationPolicy.vanillaOrientationPerspective(2, false));
+    }
+
+    @Test
+    void playerAnchoredThirdPersonDisablesVanillaDistanceWithoutChangingDetachedBehavior() {
+        assertFalse(CameraPresentationPolicy.suppressesVanillaThirdPersonDistance(false, false));
+        assertTrue(CameraPresentationPolicy.suppressesVanillaThirdPersonDistance(true, false));
+        assertTrue(CameraPresentationPolicy.suppressesVanillaThirdPersonDistance(false, true));
+    }
+
+    @Test
     void f5CycleAdvancesEveryVanillaAndBuiltInModeInOrder() {
         List<String> modes = Arrays.asList("first", "third", "shoulder", "free", "drone", "front");
         String active = "first";


### PR DESCRIPTION
## Summary

- Render an authoritative `FlightCameraTracking` sample as one quaternion-owned view instead of combining tick-owned player pitch/yaw with render-owned roll.
- Reuse the same sampled `CameraFrame` for first-/third-person presentation, quaternion-relative camera origin, front-view normalization, and legacy Euler fallbacks.
- Avoid querying the Flight provider again during `CameraSetup`; Shoulder remains Euler-compatible and external-camera compatibility remains fail-closed.

## Why

The previous generic Flight path split one quaternion across two cadences: client ticks updated player pitch/yaw while render events applied current roll. Near +/-90 degrees pitch, independent Euler branch selection could turn small continuous quaternion changes into visible jumps or twitching. It could also make the visible view diverge from frame-based picking and measurement.

## Implementation notes

- Generic authoritative Flight frames now render directly from `CameraFrame.viewAttitude()`.
- `CameraSetup` pitch, yaw, and roll are zeroed only when the sampled frame owns the quaternion view.
- Rear/front third person derives translation and perspective from that same frame; all three vanilla `thirdPersonView` reads are normalized together for front Flight views.
- The redirect cardinality is locked with `require = 3, expect = 3`.
- Camera API remains v2 and Flight API remains v9.

## Verification

- `./gradlew.bat :addons:ui-enhancements:build --no-daemon --rerun-tasks`
- 101 test suites / 339 tests: 0 failures, 0 errors, 0 skipped
- Focused policy tests cover authoritative Flight presentation, rear/front third-person normalization, and Shoulder/Drone guard behavior.